### PR TITLE
Add shouldNotIndent flag.

### DIFF
--- a/lib/snippet-expansion.js
+++ b/lib/snippet-expansion.js
@@ -1,7 +1,7 @@
 const {CompositeDisposable, Range, Point} = require('atom')
 
 module.exports = class SnippetExpansion {
-  constructor(snippet, editor, cursor, snippets) {
+  constructor(snippet, editor, cursor, snippets, shouldNotIndent) {
     this.settingTabStop = false
     this.isIgnoringBufferChanges = false
     this.onUndoOrRedo = this.onUndoOrRedo.bind(this)
@@ -17,12 +17,15 @@ module.exports = class SnippetExpansion {
     let {body, tabStopList} = this.snippet
     let tabStops = tabStopList.toArray()
 
-    let indent = this.editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
-    if (this.snippet.lineCount > 1 && indent) {
-      // Add proper leading indentation to the snippet
-      body = body.replace(/\n/g, `\n${indent}`)
+    // Don't regress default behavior
+    if (!shouldNotIndent) {
+      let indent = this.editor.lineTextForBufferRow(startPosition.row).match(/^\s*/)[0]
+      if (this.snippet.lineCount > 1 && indent) {
+        // Add proper leading indentation to the snippet
+        body = body.replace(/\n/g, `\n${indent}`)
 
-      tabStops = tabStops.map(tabStop => tabStop.copyWithIndent(indent))
+        tabStops = tabStops.map(tabStop => tabStop.copyWithIndent(indent))
+      }
     }
 
     this.editor.transact(() => {


### PR DESCRIPTION
Add a shouldNotIndent flag to allow completions with newlines to render as-is (those that have built in indentation).